### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+3270font (2.1.0-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 10 Nov 2020 09:09:58 -0000
+
 3270font (2.1.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/rbanffy/3270font/issues
+Bug-Submit: https://github.com/rbanffy/3270font/issues/new
+Repository: https://github.com/rbanffy/3270font.git
+Repository-Browse: https://github.com/rbanffy/3270font


### PR DESCRIPTION
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/3270font/59c73544-88c6-438c-8a86-0f15a3e38d88.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/59c73544-88c6-438c-8a86-0f15a3e38d88/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/59c73544-88c6-438c-8a86-0f15a3e38d88/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/59c73544-88c6-438c-8a86-0f15a3e38d88/diffoscope)).
